### PR TITLE
Feature/cifrado

### DIFF
--- a/app/utils/security.py
+++ b/app/utils/security.py
@@ -4,10 +4,38 @@ Funciones de hashing y autenticacion
 """
 
 from passlib.context import CryptContext
+from cryptography.fernet import Fernet
+import os
 
 
 #!Configuramos Bcrypt como algortimo de hashing
 pwd_context = CryptContext(schemes=["bcrypt"],deprecated="auto")
+
+#📌Generar una clave AES única si no existe
+KEY_PATH = "secret.key"
+
+if not os.path.exists(KEY_PATH):
+    key = Fernet.generate_key()
+    with open(KEY_PATH, "wb") as key_file:
+        key_file.write(key)
+else:
+    with open(KEY_PATH, "rb") as key_file:
+        key = key_file.read()
+
+#📌Crear el objeto Fernet con la clave AES
+cipher = Fernet(key)
+
+def encrypt_message(message: str) -> str:
+    """Cifra un mensaje usando AES y lo devuelve en base64."""
+    encrypted_message = cipher.encrypt(message.encode())
+    return encrypted_message.decode()
+
+def decrypt_message(encrypted_message: str) -> str:
+    """Descifra un mensaje cifrado con AES."""
+    try:
+        return cipher.decrypt(encrypted_message.encode()).decode()
+    except Exception:
+        return encrypted_message  # Si no está cifrado, lo devuelve tal cual.
 
 
 

--- a/app/utils/websocket_manager.py
+++ b/app/utils/websocket_manager.py
@@ -2,6 +2,7 @@ from typing import List
 from fastapi import WebSocket, WebSocketDisconnect
 from app.database.connection import mensajes_collection
 from datetime import datetime
+from app.utils.security import encrypt_message
 
 
 class ConnectionManager:
@@ -17,14 +18,13 @@ class ConnectionManager:
         
         """
         
-        message_data={
-            
-            "username":username,
-            "message":message,
-            "timestamp":datetime.utcnow()
-        }
+        encrypted_message = encrypt_message(message)
+        await mensajes_collection.insert_one({
+        "username": username,
+        "message": encrypted_message,
+        "timestamp": datetime.utcnow().isoformat()
+        })
         
-        mensajes_collection.insert_one(message_data)
         
     async def connect(self,websocket:WebSocket):
         

--- a/app/utils/websocket_manager.py
+++ b/app/utils/websocket_manager.py
@@ -13,16 +13,19 @@ class ConnectionManager:
         
     async def store_message(self, username:str , message:str):
         
-        """
-        Guardamos el mensaje en Mongo DB ATLAS
+        """Guarda los mensajes en MongoDB, cifrando solo los mensajes de los usuarios."""
+    
+        # No cifrar mensajes del sistema (ej: "{usuario} se ha unido")
         
-        """
-        
-        encrypted_message = encrypt_message(message)
+        if message.startswith("🔵") or message.startswith("🔴"):
+            encrypted_message = message  # Se almacena tal cual
+        else:
+            encrypted_message = encrypt_message(message)  # Cifrar solo mensajes normales
+
         await mensajes_collection.insert_one({
-        "username": username,
-        "message": encrypted_message,
-        "timestamp": datetime.utcnow().isoformat()
+            "username": username,
+            "message": encrypted_message,
+            "timestamp": datetime.utcnow().isoformat()
         })
         
         

--- a/secret.key
+++ b/secret.key
@@ -1,0 +1,1 @@
+PVbg-fwL7HUGLgD9qWdfGk1q34NWYfdl5dkk7cV7iz8=


### PR DESCRIPTION
Añadida la funcionalidad que cifra los mensajes con una clave AES, antes de aplicar su persisitencia en la base de datos Mongo ATLAS. 

Corregido el bug que cifraba todos los mensajes, incluidos los avisos del chat de conexion / desconexión de usuarios. Este bug se corrigió haciendo preguntando por como empezaban los mensajes. Si empiezan con el emoticono de inicio-cierre de sesion, no se encriptan.